### PR TITLE
Fixes share header menu

### DIFF
--- a/Alfresco/Alfresco-CE-v5.1/AAAR-Alfresco-CE-v5.1-Share/src/main/amp/config/alfresco/web-extension/site-webscripts/com/fcorti/AAAR/header/share-header.get.js
+++ b/Alfresco/Alfresco-CE-v5.1/AAAR-Alfresco-CE-v5.1-Share/src/main/amp/config/alfresco/web-extension/site-webscripts/com/fcorti/AAAR/header/share-header.get.js
@@ -3,10 +3,9 @@ var headerMenu = widgetUtils.findObject(model.jsonModel, "id", "HEADER_APP_MENU_
 
 if (headerMenu != null) {
 
-    var AAARMenu = {};
+    var AAARMenu = null;
 
     if (config.scoped["AAAR"]["visible"]) {
-
         if (config.scoped["AAAR"]["visible"].getValue() == "true") {
 
             AAARMenu = {
@@ -103,11 +102,12 @@ if (headerMenu != null) {
             }
         }
     }
-
-	// Put the item immediately before the admin console or at the end.
-    for (var i = 0; i < headerMenu.config.widgets.length && headerMenu.config.widgets[i].id != 'HEADER_ADMIN_CONSOLE'; ++i) {
+    if (AAARMenu){
+		// Put the item immediately before the admin console or at the end.
+	    for (var i = 0; i < headerMenu.config.widgets.length && headerMenu.config.widgets[i].id != 'HEADER_ADMIN_CONSOLE'; ++i) {
+	    }
+	    headerMenu.config.widgets.splice(i, 0, AAARMenu);
     }
-    headerMenu.config.widgets.splice(i, 0, AAARMenu);
 }
 
 /**


### PR DESCRIPTION
This PR addresses #36 :
For some reason, when AAARMenu is an empty object, Aikau fails to render the whole header menu.
I bet you have on extra config.xml file on your install, and have AAAR menu visibility set to true which results in the menu shoing up correctly.
In my fix, I only append the AAARMenu object to the main menu when it is not empty, and that solves it !
